### PR TITLE
fix: correct paths for vscode commands

### DIFF
--- a/vscode.reg
+++ b/vscode.reg
@@ -3,20 +3,20 @@ Windows Registry Editor Version 5.00
 ; Open files   
 [HKEY_CLASSES_ROOT\*\shell\Open with VS Code]   
 @="Edit with VS Code"   
-"Icon"="C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe,0"   
+"Icon"="C:\\Program Files\\Microsoft VS Code\\Code.exe,0"   
    
 [HKEY_CLASSES_ROOT\*\shell\Open with VS Code\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%1\""   
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%1\""   
    
 ; This will make it appear when you right click ON a folder   
 ; The "Icon" line can be removed if you don't want the icon to appear   
    
 [HKEY_CLASSES_ROOT\Directory\shell\vscode]   
 @="Open Folder as VS Code Project"   
-"Icon"="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\",0"   
+"Icon"="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\",0"   
    
 [HKEY_CLASSES_ROOT\Directory\shell\vscode\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%1\""   
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%1\""   
    
    
 ; This will make it appear when you right click INSIDE a folder   
@@ -24,24 +24,24 @@ Windows Registry Editor Version 5.00
    
 [HKEY_CLASSES_ROOT\Directory\Background\shell\vscode]   
 @="Open Folder as VS Code Project"   
-"Icon"="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\",0"   
+"Icon"="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\",0"   
    
 [HKEY_CLASSES_ROOT\Directory\Background\shell\vscode\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%V\""
-C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe,0"   
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%V\""
+C:\\Program Files\\Microsoft VS Code\\Code.exe,0"   
    
 [HKEY_CLASSES_ROOT\*\shell\Open with VS Code\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%1\""   
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%1\""   
    
 ; This will make it appear when you right click ON a folder   
 ; The "Icon" line can be removed if you don't want the icon to appear   
    
 [HKEY_CLASSES_ROOT\Directory\shell\vscode]   
 @="Open Folder as VS Code Project"   
-"Icon"="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\",0"   
+"Icon"="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\",0"   
    
 [HKEY_CLASSES_ROOT\Directory\shell\vscode\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%1\""   
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%1\""   
    
    
 ; This will make it appear when you right click INSIDE a folder   
@@ -49,7 +49,7 @@ C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe,0"
    
 [HKEY_CLASSES_ROOT\Directory\Background\shell\vscode]   
 @="Open Folder as VS Code Project"   
-"Icon"="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\",0"   
+"Icon"="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\",0"   
    
 [HKEY_CLASSES_ROOT\Directory\Background\shell\vscode\command]   
-@="\"C:\\Users\\52262\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe\" \"%V\""
+@="\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" \"%V\""


### PR DESCRIPTION
change the paths that are using a specific user and instead of that assume a central installation of VSCode in Windows